### PR TITLE
fix(colorUpdate): broken color update

### DIFF
--- a/src/components/ColorOption.vue
+++ b/src/components/ColorOption.vue
@@ -58,7 +58,7 @@ export default class ColorOption extends Vue {
       alert("Please select at least 1 color.");
       return;
     }
-    this.updateColors({ coverage: this.coverage, colors: this.colors });
+    this.updateColors({ coverage: this.coverage, colors: { ...this.colors } });
   }
 }
 </script>

--- a/src/components/DomOption.vue
+++ b/src/components/DomOption.vue
@@ -17,7 +17,7 @@
     </div>
 
     <div class="button">
-      <button @click="saveColorOption">save</button>
+      <button @click="saveDomOption">save</button>
     </div>
   </div>
 </template>
@@ -42,7 +42,7 @@ export default class DomOption extends Vue {
   selectedRange = "on";
   date = "1980-01-01";
 
-  saveColorOption() {
+  saveDomOption() {
     const date = new Date(this.date);
     const earliest = new Date("1980-01-01");
     const latest = new Date("2020-12-31");

--- a/src/components/LaserOption.vue
+++ b/src/components/LaserOption.vue
@@ -13,7 +13,7 @@
     </div>
 
     <div class="button">
-      <button @click="saveColorOption">save</button>
+      <button @click="saveLaserOption">save</button>
     </div>
   </div>
 </template>
@@ -36,7 +36,7 @@ export default class LaserOption extends Vue {
 
   selectedRange = "with";
 
-  saveColorOption() {
+  saveLaserOption() {
     this.updateLaser({ laserRange: this.selectedRange });
   }
 }

--- a/src/components/SpeedOption.vue
+++ b/src/components/SpeedOption.vue
@@ -17,7 +17,7 @@
     </div>
 
     <div class="button">
-      <button @click="saveColorOption">save</button>
+      <button @click="saveSpeedOption">save</button>
     </div>
   </div>
 </template>
@@ -42,7 +42,7 @@ export default class SpeedOption extends Vue {
   selectedRange = "lt";
   text = "";
 
-  saveColorOption() {
+  saveSpeedOption() {
     const number = Number(this.text);
     if (isNaN(number) || number < 50 || number > 200) {
       alert(


### PR DESCRIPTION
bug: when a color option is saved, changing colors will directly affect global store and generate query strings even without clicking save button

cause: updateColors action takes in `colors` object so it's passed by reference, which makes global store reference the object even without trigerring an action

solution: use spread syntax to pass colors as a new object so it doesn't reference the same one